### PR TITLE
feat(ci): add folder packaging workflow with Tesseract OCR and Poppler

### DIFF
--- a/.github/workflows/release-folder.yml
+++ b/.github/workflows/release-folder.yml
@@ -1,0 +1,192 @@
+name: Release Folder Package
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, macos-latest]
+        python-version: ['3.11']
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install Tesseract OCR and Poppler (macOS)
+      if: matrix.os == 'macos-latest'
+      run: |
+        brew install tesseract poppler
+
+    - name: Install Tesseract OCR and Poppler (Windows)
+      if: matrix.os == 'windows-latest'
+      run: |
+        choco install tesseract poppler
+        echo "$env:ProgramFiles\Tesseract-OCR" >> $env:GITHUB_PATH
+        echo "$env:ProgramFiles\poppler\bin" >> $env:GITHUB_PATH
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -e ".[dev]"
+        pip install pyinstaller
+
+    - name: Build folder package
+      run: |
+        pyinstaller OCRInvoiceParser-folder.spec
+
+    - name: Copy Tesseract and Poppler binaries (Windows)
+      if: matrix.os == 'windows-latest'
+      run: |
+        # Copy Tesseract binaries
+        cp -r "C:\Program Files\Tesseract-OCR\*" dist/OCRInvoiceParser/
+        # Copy Poppler binaries
+        cp -r "C:\Program Files\poppler\bin\*" dist/OCRInvoiceParser/
+
+    - name: Copy Tesseract and Poppler binaries (macOS)
+      if: matrix.os == 'macos-latest'
+      run: |
+        # Copy Tesseract binaries
+        cp -r /usr/local/bin/tesseract dist/OCRInvoiceParser/
+        cp -r /usr/local/share/tessdata dist/OCRInvoiceParser/
+        # Copy Poppler binaries
+        cp -r /usr/local/bin/pdf* dist/OCRInvoiceParser/
+        # Copy required libraries
+        cp -r /usr/local/lib/libpoppler* dist/OCRInvoiceParser/
+
+    - name: Create startup script (Windows)
+      if: matrix.os == 'windows-latest'
+      run: |
+        echo '@echo off' > dist/OCRInvoiceParser/run.bat
+        echo 'set PATH=%~dp0;%PATH%' >> dist/OCRInvoiceParser/run.bat
+        echo 'OCRInvoiceParser.exe %*' >> dist/OCRInvoiceParser/run.bat
+
+    - name: Create startup script (macOS)
+      if: matrix.os == 'macos-latest'
+      run: |
+        echo '#!/bin/bash' > dist/OCRInvoiceParser/run.sh
+        echo 'export PATH="$(dirname "$0"):$PATH"' >> dist/OCRInvoiceParser/run.sh
+        echo '$(dirname "$0")/OCRInvoiceParser "$@"' >> dist/OCRInvoiceParser/run.sh
+        chmod +x dist/OCRInvoiceParser/run.sh
+
+    - name: Create README for package
+      run: |
+        cat > dist/OCRInvoiceParser/README.txt << 'EOF'
+        OCR Invoice Parser - Standalone Package
+        
+        This package contains everything needed to run the OCR Invoice Parser
+        without requiring separate installation of Tesseract OCR or Poppler.
+        
+        To run the application:
+        
+        Windows:
+        - Double-click run.bat
+        - Or run OCRInvoiceParser.exe directly
+        
+        macOS:
+        - Double-click run.sh
+        - Or run ./OCRInvoiceParser directly
+        
+        Requirements:
+        - Windows 10+ or macOS 10.14+
+        - 4GB RAM recommended
+        
+        Note: This package includes Tesseract OCR and Poppler binaries.
+        No additional software installation is required.
+        EOF
+
+    - name: Create ZIP archive
+      run: |
+        cd dist
+        if [ "${{ matrix.os }}" = "windows-latest" ]; then
+          7z a -tzip OCRInvoiceParser-Windows.zip OCRInvoiceParser/
+        else
+          zip -r OCRInvoiceParser-macOS.zip OCRInvoiceParser/
+        fi
+
+    - name: Upload build artifacts
+      uses: actions/upload-artifact@v4
+      with:
+        name: OCRInvoiceParser-${{ matrix.os }}-folder
+        path: dist/OCRInvoiceParser-*.zip
+
+  create-release:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Download all artifacts
+      uses: actions/download-artifact@v4
+
+    - name: Prepare release files
+      run: |
+        # Find and rename the ZIP files
+        find . -name "OCRInvoiceParser-*.zip" -exec mv {} . \;
+
+    - name: Create Release
+      uses: softprops/action-gh-release@v1
+      with:
+        files: |
+          OCRInvoiceParser-Windows.zip
+          OCRInvoiceParser-macOS.zip
+        body: |
+          # OCR Invoice Parser v${{ github.ref_name }} - Folder Package
+
+          ## 🎉 Standalone Package Release
+
+          ### 📦 Downloads
+          - **Windows**: OCRInvoiceParser-Windows.zip
+          - **macOS**: OCRInvoiceParser-macOS.zip
+
+          ### 🚀 Quick Start
+          1. Download the ZIP file for your platform
+          2. Extract the ZIP file to a folder
+          3. Run the application:
+             - **Windows**: Double-click `run.bat` or `OCRInvoiceParser.exe`
+             - **macOS**: Double-click `run.sh` or run `./OCRInvoiceParser`
+
+          ### ✨ What's Included
+          - Complete OCR Invoice Parser application
+          - **Tesseract OCR** - No separate installation needed
+          - **Poppler** - PDF processing tools included
+          - All Python dependencies bundled
+          - Configuration files included
+
+          ### 📋 System Requirements
+          - Windows 10+ or macOS 10.14+
+          - 4GB RAM recommended
+          - No additional software installation required
+
+          ### 🔧 Manual Installation
+          If you prefer to install from source:
+          ```bash
+          git clone https://github.com/martinfou/ocrinvoice.git
+          cd ocrinvoice
+          pip install -e .
+          python run_ocr_gui.py
+          ```
+
+          ### 📝 Package Contents
+          - `OCRInvoiceParser.exe` / `OCRInvoiceParser` - Main executable
+          - `run.bat` / `run.sh` - Convenient startup scripts
+          - `tesseract.exe` / `tesseract` - OCR engine
+          - `pdf*` tools - Poppler PDF utilities
+          - `config/` - Configuration files
+          - `README.txt` - This information
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} 

--- a/OCRInvoiceParser-folder.spec
+++ b/OCRInvoiceParser-folder.spec
@@ -1,0 +1,83 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+block_cipher = None
+
+a = Analysis(
+    ['run_ocr_gui.py'],
+    pathex=[],
+    binaries=[],
+    datas=[
+        ('config/default_config.yaml', 'config'),
+        ('config/business_mappings.json', 'config'),
+        ('config/logging_config.yaml', 'config'),
+    ],
+    hiddenimports=[
+        'ocrinvoice.gui.ocr_main_window',
+        'ocrinvoice.gui.widgets.pdf_preview',
+        'ocrinvoice.gui.widgets.data_panel',
+        'ocrinvoice.gui.widgets.file_naming',
+        'ocrinvoice.parsers.invoice_parser',
+        'ocrinvoice.core.ocr_engine',
+        'ocrinvoice.core.text_extractor',
+        'ocrinvoice.core.image_processor',
+        'ocrinvoice.utils.fuzzy_matcher',
+        'ocrinvoice.utils.amount_normalizer',
+        'ocrinvoice.utils.ocr_corrections',
+        'ocrinvoice.utils.file_manager',
+        'ocrinvoice.utils.filename_utils',
+        'ocrinvoice.business.business_mapping_manager',
+        'ocrinvoice.business.database',
+        'PyQt6.QtCore',
+        'PyQt6.QtGui',
+        'PyQt6.QtWidgets',
+        'pytesseract',
+        'pdf2image',
+        'pdfplumber',
+        'PyPDF2',
+        'fuzzywuzzy',
+        'cv2',
+        'PIL',
+        'numpy',
+        'pandas',
+    ],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name='OCRInvoiceParser',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+    icon=None,
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name='OCRInvoiceParser',
+) 


### PR DESCRIPTION
- Add .github/workflows/release-folder.yml for folder-based packaging
- Add OCRInvoiceParser-folder.spec for PyInstaller --onedir builds
- Include Tesseract OCR and Poppler binaries in packages
- Create startup scripts (run.bat/run.sh) for easy execution
- Generate ZIP archives with complete standalone packages
- Separate from single-executable release workflow